### PR TITLE
fix compilation error for 'cargo test --no-default-features'

### DIFF
--- a/tests/aes.rs
+++ b/tests/aes.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "block-padding")]
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
Without this:

```
$ cargo test --no-default-features
    Updating crates.io index
   Compiling version_check v0.9.4
   Compiling typenum v1.16.0
   Compiling blobby v0.3.1
   Compiling cfg-if v1.0.0
   Compiling cpufeatures v0.2.9
   Compiling hex-literal v0.3.4
   Compiling generic-array v0.14.7
   Compiling crypto-common v0.1.6
   Compiling inout v0.1.3
   Compiling cipher v0.4.4
   Compiling aes v0.8.3
   Compiling ecb v0.1.1 (/home/capitol/project/ecb)
error[E0432]: unresolved import `aes::cipher::block_padding`
 --> tests/aes.rs:6:27
  |
6 |         use aes::cipher::{block_padding::NoPadding, BlockDecryptMut, BlockEncryptMut, KeyInit};
  |                           ^^^^^^^^^^^^^ could not find `block_padding` in `cipher`

warning: unused imports: `BlockDecryptMut`, `BlockEncryptMut`
 --> tests/aes.rs:6:53
  |
6 |         use aes::cipher::{block_padding::NoPadding, BlockDecryptMut, BlockEncryptMut, KeyInit};
  |                                                     ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0599]: no method named `encrypt_padded_mut` found for struct `Encryptor` in the current scope
  --> tests/aes.rs:22:18
   |
22 |             mode.encrypt_padded_mut::<NoPadding>(&mut buf, pt_len)
   |                  ^^^^^^^^^^^^^^^^^^ method not found in `Encryptor<Aes128>`

error[E0599]: no method named `decrypt_padded_mut` found for struct `Decryptor` in the current scope
  --> tests/aes.rs:31:18
   |
31 |             mode.decrypt_padded_mut::<NoPadding>(&mut buf).unwrap(),
   |                  ^^^^^^^^^^^^^^^^^^ method not found in `Decryptor<Aes128>`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
warning: `ecb` (test "aes") generated 1 warning
error: could not compile `ecb` (test "aes") due to 3 previous errors; 1 warning emitted
warning: build failed, waiting for other jobs to finish...
```

Background is that Debian's build system runs the tests for every feature and also without features and with all of them enabled.